### PR TITLE
Use `cmake` as build sysytem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ prep.sh
 !.gitkeep
 manual
 docs/website.*
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(CWang)
+enable_language(Fortran)
+
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+set(CMAKE_Fortran_COMPILER mpif90)
+set(CMAKE_C_COMPILER mpicc)
+set(CMAKE_Fortran_FLAGS "-cpp -O3 -g -DBAD_ZDU=1 -DDRAW_SHOW=1 -DDRAW_EVINCE=0")
+
+file(GLOB SRC_FILE "source/*/source/*")
+
+add_library(pack ${SRC_FILE})
+


### PR DESCRIPTION
Use `cmake` as build system.
It simplifies the compilation process
Method to compile is the following
- `cd build`
- `cmake ..`
![image](https://user-images.githubusercontent.com/11623447/79039126-adc6da00-7c11-11ea-8438-82a784824930.png)
- `make -j`
![image](https://user-images.githubusercontent.com/11623447/79039140-c800b800-7c11-11ea-862d-24b119a3e095.png)
- get your library
![image](https://user-images.githubusercontent.com/11623447/79039150-da7af180-7c11-11ea-804c-f6741abceee3.png)
---
If possible, you can even remove current script like `pack.sh`, `make.sh` and `clean.sh`.